### PR TITLE
Adicionar Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rails server -p $PORT
+release: bundle exec rake db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec rails server -p $PORT
+web: bundle exec rails server -p $PORT -e $RAILS_ENV
 release: bundle exec rake db:migrate


### PR DESCRIPTION
Sem este arquivo, o Heroku não será capaz de realizar algumas tarefas necessárias para o CD do sistema (por exemplo, o rake db:migrate).