### PR TITLE
views/news: tornar news-card responsivo.

### DIFF
--- a/app/assets/stylesheets/news.scss
+++ b/app/assets/stylesheets/news.scss
@@ -3,18 +3,9 @@
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
 .news-card div.card-image {
-    width: 30%;
     min-height: 15em;
     max-height: 100%;
     background-size: cover;
     background-position: center center;
     flex-shrink: 0.2;
 }
-
-.news-card p.card-text{
-    width:750px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-

--- a/app/views/news/_news_card.html.erb
+++ b/app/views/news/_news_card.html.erb
@@ -22,8 +22,14 @@
 <div class="news-card card bg-light mb-3 row d-flex flex-row">
     <% if item.image_url %>
         <div class="card-image col-sm-4" style="background-image: url('<%= item.image_url %>');"></div>
-    <% end %>
-    <div class="card-body col-sm-8">
+	<% end %>
+	
+	<%# Apenas usar uma coluna menor caso haja uma imagem %>
+	<% if item.image_url %>
+		<div class="card-body col-sm-8">
+	<% else %>
+		<div class="card-body col-sm-12">
+	<% end %>
         <h5 class="card-title"><%= item.title %></h5>
         <p class="card-text text-truncate"><%= strip_tags(item.summary) %></p>
 	<br><br><br>

--- a/app/views/news/_news_card.html.erb
+++ b/app/views/news/_news_card.html.erb
@@ -19,13 +19,13 @@
 </script>
 
 
-<div class="news-card card bg-light mb-3 d-flex flex-row">
+<div class="news-card card bg-light mb-3 row d-flex flex-row">
     <% if item.image_url %>
-        <div class="card-image" style="background-image: url('<%= item.image_url %>');"></div>
+        <div class="card-image col-sm-4" style="background-image: url('<%= item.image_url %>');"></div>
     <% end %>
-    <div class="card-body">
+    <div class="card-body col-sm-8">
         <h5 class="card-title"><%= item.title %></h5>
-        <p class="card-text"><%= strip_tags(item.summary) %></p>
+        <p class="card-text text-truncate"><%= strip_tags(item.summary) %></p>
 	<br><br><br>
         <a href="<%= item.url %>" target=_blank class="card-link">
 	<button type="button" onclick="access_counter(<%= item.id %>)" class="btn btn-dark">Ler a notícia</button>


### PR DESCRIPTION
Antes, a imagem apenas diminuia/sumia em telas com menor largura. Agora, a imagem vai para cima do card, caso não haja espaço horizontal suficiente.

![responsive](https://user-images.githubusercontent.com/5082637/69591558-d6876380-0fd1-11ea-8c18-bbc2d4f2f2a2.gif)
